### PR TITLE
sync: from public main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: Sync to Private Repo
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout del repo público
+        uses: actions/checkout@v3
+
+      - name: Sincronizar con privado sin borrar nada
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+          # Clona el repo privado con .git incluido
+          git clone https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/BorisFaj/remedios.git private-repo
+
+          # Copia archivos del repo público al repo privado
+          rsync -av --progress ./ private-repo/ \
+            --exclude=".git/" \
+            --exclude=".github/" \
+            --exclude=".gitignore" \
+            --exclude="remedios/log/" \
+            --exclude="test/" \
+            --exclude="README.md" \
+            --exclude="diagrama.webp"
+
+          cd private-repo
+          git add .
+          git commit -m "Sync desde repo público 🚀" || echo "Sin cambios"
+          git push origin main


### PR DESCRIPTION
Este commit sincroniza los últimos cambios desde el repositorio público (remedios-public) al repositorio privado.

Se han copiado todos los archivos actualizados, respetando la exclusión de carpetas y archivos específicos como `remedios/log/`, `test/`, `.github/`, `README.md` y otros elementos exclusivos del entorno privado.

Esta sincronización se realiza de forma automática mediante una GitHub Action al hacer push en la rama `main` del repositorio público.

Un beso.